### PR TITLE
A few major fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,30 +128,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# AWS User-specific
-.idea/**/aws.xml
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
+# PyCharm / JetBrains IDEs
+/.idea
 
 # pa_to_ap specific stuff
 /podcast_addict_extracted

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,33 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# pa_to_ap specific stuff
+/podcast_addict_extracted
+/*.db
+/*.backup

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Migrate data from Podcast Addict's to AntennaPod's database
 
 This does not use any IDs for matching feeds and episodes from one db to another, as those tend to be very unreliable. (They're supposed to stay the same, but often they don't.) Instead, we match them by their name and, in some cases, other attributes. This will work even if the name changed. For example, when using the script one episode's name changed from something like `123. Great Title` to just `Great Title`, but they were still matched.
 
+## Configuration
+There are a few optional configuration settings you can change by editing the variables  at the top of `pa_to_ap.py` before running the script.
+
+MATCH_ON_EPISODE_URL_IF_COULD_NOT_FIND_A_MATCH_OTHERWISE = True
+* `TRANSFER_DOWNLOADED_EPISODES` controls if existing downloads in Podcast Addict are copied to AntennaPod. 
+   Additional steps are required, see steps below.
+    * Default: `True` (downloads are transferred.)
+* `EPISODES_DIR_PATH ` controls the directory path for transferred episodes (to which you have to manually copy/move the files to).
+    * Default: `/storage/emulated/0/Android/data/de.danoeh.antennapod/files/media/from_podcast_addict`
+* `MATCH_ON_EPISODE_URL_IF_COULD_NOT_FIND_A_MATCH_OTHERWISE` If a name match for a given episode is not found, this setting controls if we should try to match on the episode media URL instead.
+    * Default: `True` (URL match is used as a fallback.)
+
 ## Steps
 
 0. Install Python 3.8 or later
@@ -20,17 +32,16 @@ This does not use any IDs for matching feeds and episodes from one db to another
 5. Run the [`pa_to_ap.py`](pa_to_ap.py) script (AntennaPod db file will be **modified**!) in a terminal
 6. Confirm that matches are correct (if they aren't you may need to increase `min_similarity`)
 7. Copy the modified db file back to your phone
-8. Create `/storage/emulated/0/Android/data/de.danoeh.antennapod/files/media/from_podcast_addict` 
-9. Manually move (or copy) the folders **inside**
-`/storage/emulated/0/Android/data/com.bambuna.podcastaddict/files/podcast/`
-**to**
-`/storage/emulated/0/Android/data/de.danoeh.antennapod/files/media/from_podcast_addict`
-   as AntennaPod cannot access the files under the other app's directory (Consider making a backup of these files.)
-10. Import the modified db in AntennaPod
+8. If you chose to enable `TRANSFER_DOWNLOADED_EPISODES` (this is on by default):
+    1. Create `/storage/emulated/0/Android/data/de.danoeh.antennapod/files/media/from_podcast_addict` 
+    2. Manually move (or copy) the folders **inside**
+    `/storage/emulated/0/Android/data/com.bambuna.podcastaddict/files/podcast/`
+    **to**
+    `/storage/emulated/0/Android/data/de.danoeh.antennapod/files/media/from_podcast_addict`
+       as AntennaPod cannot access the files under the other app's directory (Consider making a backup of these files.)
+9. Import the modified db in AntennaPod
 
 Enjoy!
-
-Of course, you can change the location (to which you have to manually copy/move the files to) by modifying the `EPISODES_DIR_PATH` before running the script.
 
 ## Warning
 Note that this is somewhat rough and will likely not handle a lot of edge cases.

--- a/pa_to_ap.py
+++ b/pa_to_ap.py
@@ -14,6 +14,7 @@ from matcher import ObjectListMatcher
 
 CUR_PATH = Path()
 
+TRANSFER_DOWNLOADED_EPISODES = True
 EPISODES_DIR_PATH = '/storage/emulated/0/Android/data/de.danoeh.antennapod/files/media/from_podcast_addict'
 MATCH_ON_EPISODE_URL_IF_COULD_NOT_FIND_A_MATCH_OTHERWISE = True
 
@@ -208,7 +209,7 @@ def transfer_from_feed_to_feed(podcast_addict_cur: Cursor,  #
                 "INSERT INTO Favorites (feeditem, feed) VALUES "
                 "(?, ?)", (ap_ep[0], ap.id))
 
-        if pa_ep[4]:
+        if pa_ep[4] and TRANSFER_DOWNLOADED_EPISODES:
             transfer_from_dld_ep_to_ep(antenna_pod_cur, podcast_addict_cur,  #
                                        pa_ep, ap_ep, pa.folder_name)
 


### PR DESCRIPTION
Thanks for publishing this awesome tool. It was recommended to me by the AntennaPod maintainers when I was looking to migrate off of Podcast Addict. I got it working but it took some effort. Here's a PR with all my fixes and new features:

* (feat) Perform feed matching by feed URL instead of fuzzy matching which seems to have 100% success rate, old method wasn't working at all for me. I believe this closes https://github.com/CreamyCookie/pa_to_ap/issues/2 if it was the same root cause.
* (fix) Ignore uninitialized PA feeds
* (feat) Add support for transferring in-progress episodes
  * This doesn't seem to work 100% of the time, sometimes AP restarts an in-progress episode after the transfer, but it seems to work at least some of the time. I'm not really sure why...
* (fix) Fix bug in episode URL match fallback logic where it wasn't doing anything when a match was found, and add log message when URL match is successful
* (fix) Fix error from referencing `SimpleChapters.type` column which doesn't exist in AP 3.6.1
* (fix) Remove some unnecessary repeated calls to `print` function where `\n` literal could be used instead.
* (feat) Add `TRANSFER_DOWNLOADED_EPISODES` setting to control if downloaded episodes are copied. Add additional docs to README about this and other flags.
* (feat) Add support for transferring tags.
* (dev tooling) Update `.gitignore` for `pa_to_ap` i/o files and PyCharm IDE

I've tested these changes on my own Podcast Addict and AntennaPod apps with a very large database (187 feeds, 442 downloaded episodes) and spot-checked the results. Everything seems to be working apart from the aforementioned issue with in-progress episodes, and I'm not really sure if I can fix that. I think this is OK to merge as-is for now.
